### PR TITLE
feat: update vencord guide and fix emoji packs api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ app.get('/api/dist/betterdiscord', async c => {
 	});
 });
 
+/*
 app.get('/api/dist/vencord', async c => {
 	const response = await fetch('https://raw.githubusercontent.com/Pitu/Magane/master/dist/magane.vencord.js');
 	if (!response.ok) return c.json({ message: 'Failed to fetch plugin' }, 500);
@@ -54,6 +55,7 @@ app.get('/api/dist/vencord', async c => {
 		}
 	});
 });
+*/
 
 app.get('/api/proxy/emoji/:id', async c => {
 	const { id } = c.req.param();
@@ -65,8 +67,37 @@ app.get('/api/proxy/emoji/:id', async c => {
 	const data = await response.text();
 
 	const title = /<title[^>]*>([^<]+)<\/title>/.exec(data)?.[1]?.split(' – LINE Emoji | LINE STORE')[0];
-	const len = (data.match(/FnStickerPreviewItem/g) ?? []).length;
-	return c.json({ title, id, len });
+
+	let len = (data.match(/FnStickerPreviewItem/g) ?? []).length;
+	let hasAnimation = /MdIcoPlay_b/g.test(data);
+
+	// If unable to determine emojis count by parsing its store page, assume region-locked or other reasons
+	// This is not default because emojis meta.json do not have their pack titles
+	if (len === 0) {
+		const urls = [
+			`https://stickershop.line-scdn.net/sticonshop/v1/${id}/sticon/iphone/meta.json`,
+			`https://stickershop.line-scdn.net/sticonshop/v1/${id}/sticon/android/meta.json`
+		];
+
+		let dataMeta;
+		for (const url of urls) {
+			try {
+				const responseMeta = await fetch(url);
+				if (!responseMeta.ok) continue;
+				dataMeta = await responseMeta.json();
+				if (dataMeta) break;
+			} catch {
+				continue;
+			}
+		}
+
+		if (!dataMeta) return c.json('Failed to fetch emoji pack', 400);
+
+		len = dataMeta.orders.length
+		hasAnimation = dataMeta.sticonResourceType === 'ANIMATION'
+	}
+
+	return c.json({ title, id, len, hasAnimation });
 });
 
 app.get('/api/proxy/sticker/:id', async c => {

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -142,8 +142,8 @@
 					</div>
 					<div class="tabContent">
 						<div class="content" style="margin-top: 2em;">
-							<p>If you are a <a href="https://vencord.dev/">Vencord</a> user you need to download the plugin and compile Vencord yourself. You can find out how by following <a href="https://github.com/Pitu/Magane?tab=readme-ov-file#vencord" target="_blank">our guide</a>.
-							<p class="text-center"><a href="/api/dist/vencord" target="_blank" class="btn btn-primary btn-lg">Download magane.vencord.js</a></p>
+							<p>If you are a <a href="https://vencord.dev/">Vencord</a> user, you need to download the plugin and compile Vencord yourself. You can find out how by following our guide:
+							<p class="text-center"><a href="https://github.com/Pitu/Magane?tab=readme-ov-file#vencord" target="_blank" class="btn btn-primary btn-lg">How to use in Vencord?</a></p>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
- Disable `/api/dist/vencord`, and update homepage's Vencord install screen.  
Since Vencord now require 2 files, it's better to just redirect them to the full guide in the main repo.
- Update `/api/proxy/emoji/:id` to return `hasAnimation` status.

2026 force-push:
- `meta.json` fallback for emojis packs if their store page is unavailable due to region-lock or other reasons.